### PR TITLE
fix: pull correct stock level for master products (CO-3385)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 - CO-3043 - fix taxrate not found
 - CO-2117 - fix delivery time not set
 - CO-2793 - fix base price not set
+- CO-3385 - fix send stock
 
 ## 2.0.2 _2025-11-02_
 - CO-2508 - Use wawi tracking lists

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -151,14 +151,12 @@ class ProductController extends ProductPriceController implements PullInterface,
     protected function createJtlProduct(PrestaProduct $prestaProduct): JtlProduct
     {
         $prestaAttributes = $prestaProduct->getAttributesGroups($this->getPrestaContextLanguageId());
-        $prestaStock      = new \StockAvailable($prestaProduct->id);
         $prestaProductId  = \is_int($prestaProduct->id)
             ? $prestaProduct->id
             : throw new \RuntimeException('Product ID is not an integer');
 
-        //we ignore this line as prestashop hasn't updated their PHPDoc yet
-        //@phpstan-ignore-next-line
-        \is_numeric($prestaStock->quantity) ? $prestaQuantity = (float)$prestaStock->quantity : $prestaQuantity = 0.0;
+        $prestaQuantity   = (float)\StockAvailable::getQuantityAvailableByProduct($prestaProductId);
+        $prestaOutOfStock = (int)\StockAvailable::outOfStock($prestaProductId);
 
         $jtlProduct = (new JtlProduct())
             ->setId(new Identity((string)$prestaProduct->id))
@@ -183,8 +181,8 @@ class ProductController extends ProductPriceController implements PullInterface,
             ->setI18ns(...$this->createJtlProductTranslations($prestaProductId))
             ->setAvailableFrom($this->createDateTime($prestaProduct->available_date))
             ->setBasePriceUnitName($prestaProduct->unity ?? '') //phpcs:ignore @phpstan-ignore-line
-            ->setConsiderStock($prestaStock->out_of_stock === 0 || $prestaStock->out_of_stock === 2)
-            ->setPermitNegativeStock($prestaStock->out_of_stock === 0)
+            ->setConsiderStock($prestaOutOfStock === 0 || $prestaOutOfStock === 2)
+            ->setPermitNegativeStock($prestaOutOfStock === 0)
             ->setIsActive(true)
             ->setIsTopProduct((bool)$prestaProduct->on_sale)
             ->setPurchasePrice((float)$prestaProduct->wholesale_price)

--- a/tests/Support/Controller/TestableProductController.php
+++ b/tests/Support/Controller/TestableProductController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Controller;
+
+use Db;
+use Jtl\Connector\Core\Model\Product as JtlProduct;
+use jtl\Connector\Presta\Controller\ProductController;
+use Product as PrestaProduct;
+use Psr\Log\NullLogger;
+
+/**
+ * Overrides the constructor to avoid Db::getInstance() and stubs out the
+ * DB-backed createJtl* sub-mappers so that createJtlProduct() can be
+ * exercised in isolation, e.g. to verify stock-level mapping.
+ */
+final class TestableProductController extends ProductController
+{
+    public function __construct()
+    {
+        $this->db             = new Db();
+        $this->logger         = new NullLogger();
+        $this->controllerName = 'ProductController';
+    }
+
+    protected function getPrestaContextLanguageId(): int
+    {
+        return 1;
+    }
+
+    protected function getPrestaContextShopId(): int
+    {
+        return 1;
+    }
+
+    protected function createJtlSpecialPrices(PrestaProduct $prestaProduct): array
+    {
+        return [];
+    }
+
+    protected function createJtlSpecialAttributes(PrestaProduct $prestaProduct): array
+    {
+        return [];
+    }
+
+    protected function createJtlProductCategories(PrestaProduct $prestaProduct): array
+    {
+        return [];
+    }
+
+    protected function createJtlProductTranslations(int $prestaProductId): array
+    {
+        return [];
+    }
+
+    public function exposeCreateJtlProduct(PrestaProduct $prestaProduct): JtlProduct
+    {
+        return $this->createJtlProduct($prestaProduct);
+    }
+}

--- a/tests/Support/PrestaShopStubs.php
+++ b/tests/Support/PrestaShopStubs.php
@@ -1264,6 +1264,18 @@ if (!class_exists('SpecificPrice')) {
 if (!class_exists('StockAvailable')) {
     class StockAvailable
     {
+        /** @var array<int, int> keyed by productId */
+        public static array $mockQuantities = [];
+
+        /** @var array<int, int|bool> keyed by productId */
+        public static array $mockOutOfStock = [];
+
+        public static function resetMock(): void
+        {
+            static::$mockQuantities = [];
+            static::$mockOutOfStock = [];
+        }
+
         public static function setQuantity(
             int $productId,
             int $productAttributeId = 0,
@@ -1278,7 +1290,12 @@ if (!class_exists('StockAvailable')) {
             int $productAttributeId = 0,
             ?int $shopId = null
         ): int {
-            return 0;
+            return static::$mockQuantities[$productId] ?? 0;
+        }
+
+        public static function outOfStock(int $productId, ?int $shopId = null): int|bool
+        {
+            return static::$mockOutOfStock[$productId] ?? 0;
         }
     }
 }

--- a/tests/Unit/Controller/ProductController/CreateJtlProductStockLevelTest.php
+++ b/tests/Unit/Controller/ProductController/CreateJtlProductStockLevelTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Controller\ProductController;
+
+use PHPUnit\Framework\TestCase;
+use Product as PrestaProduct;
+use StockAvailable;
+use Tests\Support\Controller\TestableProductController;
+
+/**
+ * createJtlProduct() must always map the current stock level, regardless of
+ * any shop-level setting, since PrestaShop has no configuration to disable
+ * stock synchronisation. Regression test for a bug where the stock quantity
+ * was read from `new StockAvailable($productId)`, which loads a row by the
+ * unrelated primary key `id_stock_available` instead of by `id_product` and
+ * therefore returned wrong (usually zero) data for master products.
+ */
+final class CreateJtlProductStockLevelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StockAvailable::resetMock();
+    }
+
+    protected function tearDown(): void
+    {
+        StockAvailable::resetMock();
+    }
+
+    public function testMapsStockLevelFromStockAvailableByProduct(): void
+    {
+        StockAvailable::$mockQuantities = [42 => 300];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertSame(300.0, $result->getStockLevel());
+    }
+
+    public function testMapsZeroStockLevel(): void
+    {
+        StockAvailable::$mockQuantities = [42 => 0];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertSame(0.0, $result->getStockLevel());
+    }
+
+    public function testUsesTheGivenProductIdToLookUpStock(): void
+    {
+        // Guards the id used to look up the quantity: it must be the product id
+        // passed to createJtlProduct(), not some other, unrelated id.
+        StockAvailable::$mockQuantities = [42 => 300, 99 => 5];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertSame(300.0, $result->getStockLevel());
+    }
+
+    public function testConsidersStockWhenOutOfStockDenied(): void
+    {
+        StockAvailable::$mockOutOfStock = [42 => 0];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertTrue($result->getConsiderStock());
+        self::assertTrue($result->getPermitNegativeStock());
+    }
+
+    public function testConsidersStockWhenOutOfStockUsesGlobalSetting(): void
+    {
+        StockAvailable::$mockOutOfStock = [42 => 2];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertTrue($result->getConsiderStock());
+        self::assertFalse($result->getPermitNegativeStock());
+    }
+
+    public function testDoesNotConsiderStockWhenOrdersAreAlwaysAllowed(): void
+    {
+        StockAvailable::$mockOutOfStock = [42 => 1];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertFalse($result->getConsiderStock());
+        self::assertFalse($result->getPermitNegativeStock());
+    }
+
+    public function testTreatsOutOfStockFalseReturnAsDenyOrders(): void
+    {
+        // Real PrestaShop's StockAvailable::outOfStock() returns bool false for an
+        // invalid product id; the (int) cast in the controller must not crash on it
+        // and must fall back to the "deny orders" (0) semantics.
+        StockAvailable::$mockOutOfStock = [42 => false];
+        $controller = new TestableProductController();
+
+        $result = $controller->exposeCreateJtlProduct(new PrestaProduct(42));
+
+        self::assertTrue($result->getConsiderStock());
+        self::assertTrue($result->getPermitNegativeStock());
+    }
+}


### PR DESCRIPTION
## Summary
- `createJtlProduct()` loaded the stock via `new StockAvailable($productId)`, which resolves by the unrelated primary key `id_stock_available` instead of `id_product` — master products therefore synced a wrong (usually zero) stock level on `product.pull`.
- Replaced with `StockAvailable::getQuantityAvailableByProduct()` / `StockAvailable::outOfStock()`, the same static API already used correctly for product variations in the same controller.
- PrestaShop has no setting to enable/disable stock sync — it is expected to always run.

## Test plan
- [x] New regression tests in `tests/Unit/Controller/ProductController/CreateJtlProductStockLevelTest.php` (stock level, out-of-stock flag mapping incl. the `int|bool` edge case of PrestaShop's `outOfStock()`)
- [x] `composer phpcs` — clean
- [x] `composer phpstan` (level max) — clean
- [x] Full `phpunit` suite (520 tests) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)